### PR TITLE
options (props) to block scroll up & down

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ goToPage = (pageNumber) => {
 | scrollUnavailable  | function | callback, is calling when someone tries to scroll over last or first child component | |
 | containerHeight | number/string | height of react-page-scroller element | 100vh |
 | containerWidth | number/string | width of react-page-scroller element | 100vw |
+| blockScrollUp | bool | block scroll up | false |
+| blockScrollDown | bool | block scroll up | false |
 
 ## Dependencies
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,14 +26,18 @@ export default class ReactPageScroller extends React.Component {
         pageOnChange: PropTypes.func,
         scrollUnavailable: PropTypes.func,
         containerHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-        containerWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+        containerWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+        blockScrollUp: PropTypes.bool,
+        blockScrollDown: PropTypes.bool
     };
 
     static defaultProps = {
         animationTimer: 1000,
         transitionTimingFunction: "ease-in-out",
         containerHeight: "100vh",
-        containerWidth: "100vw"
+        containerWidth: "100vw",
+        blockScrollUp: false,
+        blockScrollDown: false
     };
 
     constructor(props) {
@@ -222,7 +226,7 @@ export default class ReactPageScroller extends React.Component {
     };
 
     [scrollWindowUp] = () => {
-        if (!this[scrolling]) {
+        if (!this[scrolling] && !this.props.blockScrollUp) {
             if (!_.isNil(this["container_" + (this.state.componentIndex - 1)])) {
                 this[scrolling] = true;
                 this._pageContainer.style.transform = `translate3d(0, ${(this.state.componentIndex - 1) * -100}%, 0)`;
@@ -245,7 +249,7 @@ export default class ReactPageScroller extends React.Component {
     };
 
     [scrollWindowDown] = () => {
-        if (!this[scrolling]) {
+        if (!this[scrolling] && !this.props.blockScrollDown) {
             if (!_.isNil(this["container_" + (this.state.componentIndex + 1)])) {
                 this[scrolling] = true;
                 this._pageContainer.style.transform = `translate3d(0, ${(this.state.componentIndex + 1) * -100}%, 0)`;


### PR DESCRIPTION
fixes feature request #18 

props `blockScrollUp` and `blockScrollDown` will block scroll up & down if set to true. Link it to the container state to have control scrolling based on state. 