### PR TITLE
Fix outline glitch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -318,6 +318,7 @@ const ReactPageScroller = ({
           height: "100%",
           width: "100%",
           transition: `transform ${animationTimer}ms ${transitionTimingFunction}`,
+          outline: "none"
         }}
         tabIndex={0}
       >


### PR DESCRIPTION
If you click on any of the pages, an outline appears on the border of the page.