### PR TITLE
Moved react, react-dom, and react-rouger to be peerDependencies for use in projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "gh-pages": "^1.1.0",
     "lodash": "^4.17.15",
     "prop-types": "^15.6.2",
+    "react-bootstrap": "^0.32.1"
+  },
+  "peerDependencies": {
     "react": "^16.10.2",
-    "react-bootstrap": "^0.32.1",
     "react-dom": "^16.10.2",
     "react-router-dom": "^4.3.1"
   },
@@ -43,7 +45,10 @@
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^1.7.0",
     "nwb": "^0.23.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.18.2",
+    "react": "^16.10.2",
+    "react-dom": "^16.10.2",
+    "react-router-dom": "^4.3.1"
   },
   "author": "Viktor Liegostaiev",
   "homepage": "https://vikliegostaiev.github.io/react-page-scroller/",


### PR DESCRIPTION
Currently `react`, `react-dom`, and `react-router-dom` are listed as dependencies of this project.

Upon trying to install this package into an existing project and using it, errors are thrown because this package has its own version of react as a dependency.

Replication:
`npx create-react-app <project name>`

`npm install` this package

`npm ls react` you will see 2 version of react, one for the base project and 1 from this package

Moving the dependencies to peerDependencies and devDependencies allows projects to use this package.

https://classic.yarnpkg.com/en/docs/dependency-types/