### PR TITLE
Render array of components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+} from "react";
 import PropTypes from "prop-types";
 
 import * as Events from "./Events";
@@ -52,6 +58,7 @@ const ReactPageScroller = ({
   const scrollContainer = useRef(null);
   const pageContainer = useRef(null);
   const lastScrolledElement = useRef(null);
+  children = useMemo(() => React.Children.toArray(children), [children]);
 
   const scrollPage = useCallback(
     nextComponentIndex => {


### PR DESCRIPTION
This pull request solves the issue #51 (regarding the rendering of a dynamic list of components, for example with `{.map()}`).
It does so by flattening the list of children via `React.Children.toArray()`.
Please review it because this issue is really annoying and it's damaging my productivity.
Thanks