### PR TITLE
Add support react 17 cleanup functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -246,11 +246,12 @@ const ReactPageScroller = ({
   );
 
   useEffect(() => {
-    scrollContainer.current.addEventListener(Events.TOUCHMOVE, touchMove);
-    scrollContainer.current.addEventListener(Events.KEYDOWN, keyPress);
+    const instance = scrollContainer.current;
+    instance.addEventListener(Events.TOUCHMOVE, touchMove);
+    instance.addEventListener(Events.KEYDOWN, keyPress);
     return () => {
-      scrollContainer.current.removeEventListener(Events.TOUCHMOVE, touchMove);
-      scrollContainer.current.removeEventListener(Events.KEYDOWN, keyPress);
+      instance.removeEventListener(Events.TOUCHMOVE, touchMove);
+      instance.removeEventListener(Events.KEYDOWN, keyPress);
     };
   }, [touchMove, keyPress]);
 


### PR DESCRIPTION
The latest version of Nextjs uses react 17 which always execute all effect cleanup functions (for all components) before it runs any new effects.

>The problem is that someRef.current is mutable, so by the time the cleanup function runs, it may have been set to null. The solution is to capture any mutable values inside the effect

closes #73  based on https://github.com/VikLiegostaiev/react-page-scroller/issues/73#issuecomment-825413277